### PR TITLE
Add demo services and dev certs

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -3,3 +3,6 @@
 ## [Unreleased]
 - Initial repository scaffolding with multiple Django projects: identity-provider, website, billing-api, inventory-api.
 - Added shared JWT authentication utilities and middleware.
+- Implemented demo website page and DRF health/private endpoints for each API.
+- Added identity provider login/logout pages and login API.
+- Added Makefile and dev certificate generation script.

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,26 @@
+VF_JWT_SECRET ?= change-me
+
+.PHONY: up dev-cert
+
+up:
+$(MAKE) -j4 run-identity run-website run-billing run-inventory
+
+run-identity:
+VF_JWT_SECRET=$(VF_JWT_SECRET) python identity-provider/manage.py runserver 8001
+
+run-website:
+VF_JWT_SECRET=$(VF_JWT_SECRET) python website/manage.py runserver 8002
+
+run-billing:
+VF_JWT_SECRET=$(VF_JWT_SECRET) python billing-api/manage.py runserver 8003
+
+run-inventory:
+VF_JWT_SECRET=$(VF_JWT_SECRET) python inventory-api/manage.py runserver 8004
+
+
+device-cert:
+@echo "Deprecated target name: use dev-cert"
+
+
+dev-cert:
+./scripts/get_dev_certs.sh

--- a/README.md
+++ b/README.md
@@ -23,11 +23,9 @@ pip install -r requirements.txt
 export VF_JWT_SECRET="super-secret-key"
 ```
 
-Then run any project using Django's development server:
+You can start all services at once using the provided Makefile:
 
 ```bash
-cd identity-provider
-python manage.py runserver
+make dev-cert   # generates self-signed certificates
+make up         # runs all projects on different ports
 ```
-
-Repeat for the other projects as needed.

--- a/billing-api/billing/urls.py
+++ b/billing-api/billing/urls.py
@@ -1,0 +1,7 @@
+from django.urls import path
+from . import views
+
+urlpatterns = [
+    path('health/', views.health, name='health'),
+    path('private/', views.private, name='private'),
+]

--- a/billing-api/billing/views.py
+++ b/billing-api/billing/views.py
@@ -1,3 +1,15 @@
-from django.shortcuts import render
+from rest_framework.decorators import api_view, permission_classes
+from rest_framework.permissions import AllowAny, IsAuthenticated
+from rest_framework.response import Response
 
-# Create your views here.
+
+@api_view(["GET"])
+@permission_classes([AllowAny])
+def health(request):
+    return Response({"status": "ok"})
+
+
+@api_view(["GET"])
+@permission_classes([IsAuthenticated])
+def private(request):
+    return Response({"user": request.user.username})

--- a/billing-api/main/settings.py
+++ b/billing-api/main/settings.py
@@ -38,6 +38,7 @@ INSTALLED_APPS = [
     "django.contrib.sessions",
     "django.contrib.messages",
     "django.contrib.staticfiles",
+    "rest_framework",
     "billing",
 ]
 
@@ -126,3 +127,5 @@ DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 
 # JWT configuration
 JWT_SECRET = os.environ.get("VF_JWT_SECRET", "change-me")
+SSO_COOKIE_DOMAIN = os.environ.get("SSO_COOKIE_DOMAIN", "localhost")
+DEFAULT_REDIRECT_URL = os.environ.get("DEFAULT_REDIRECT_URL", "/")

--- a/billing-api/main/urls.py
+++ b/billing-api/main/urls.py
@@ -16,8 +16,9 @@ Including another URLconf
 """
 
 from django.contrib import admin
-from django.urls import path
+from django.urls import path, include
 
 urlpatterns = [
     path("admin/", admin.site.urls),
+    path("", include("billing.urls")),
 ]

--- a/identity-provider/identity_app/templates/identity_app/login.html
+++ b/identity-provider/identity_app/templates/identity_app/login.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<head><title>Login</title></head>
+<body>
+  <h1>Login</h1>
+  <form method="post">
+    {% csrf_token %}
+    <label>Username: <input type="text" name="username"></label><br>
+    <label>Password: <input type="password" name="password"></label><br>
+    <button type="submit">Login</button>
+  </form>
+</body>
+</html>

--- a/identity-provider/identity_app/urls.py
+++ b/identity-provider/identity_app/urls.py
@@ -1,0 +1,9 @@
+from django.urls import path
+from . import views
+from rest_framework.views import APIView
+
+urlpatterns = [
+    path('login/', views.login_user, name='login'),
+    path('logout/', views.logout_user, name='logout'),
+    path('api/login/', views.LoginAPIView.as_view(), name='api_login'),
+]

--- a/identity-provider/identity_app/views.py
+++ b/identity-provider/identity_app/views.py
@@ -1,3 +1,70 @@
+import datetime
+from django.conf import settings
+from django.contrib.auth import authenticate
+from django.http import HttpResponseForbidden, HttpResponseRedirect
 from django.shortcuts import render
+from rest_framework.views import APIView
+from rest_framework.response import Response
+from rest_framework import status
+from common.jwt_auth import utils
 
-# Create your views here.
+
+def login_user(request):
+    """Render login form or authenticate user and set JWT cookie."""
+    if request.method == "GET":
+        return render(request, "identity_app/login.html")
+
+    username = request.POST.get("username")
+    password = request.POST.get("password")
+    user = authenticate(username=username, password=password)
+    if user is None:
+        return HttpResponseForbidden("Invalid login")
+
+    payload = {
+        "username": user.username,
+        "email": user.email,
+        "iat": datetime.datetime.utcnow(),
+    }
+    token = utils.encode_jwt(payload)
+
+    redirect_url = request.GET.get("redirect_uri", settings.DEFAULT_REDIRECT_URL)
+    response = HttpResponseRedirect(redirect_url)
+    response.set_cookie(
+        "jwt",
+        token,
+        domain=settings.SSO_COOKIE_DOMAIN,
+        httponly=True,
+        secure=True,
+        samesite="Lax",
+        max_age=3600,
+    )
+    return response
+
+
+def logout_user(request):
+    """Clear the JWT cookie across the domain."""
+    response = HttpResponseRedirect(settings.DEFAULT_REDIRECT_URL)
+    response.delete_cookie("jwt", domain=settings.SSO_COOKIE_DOMAIN)
+    return response
+
+
+class LoginAPIView(APIView):
+    """API endpoint to obtain JWT via username and password."""
+
+    authentication_classes = []
+    permission_classes = []
+
+    def post(self, request):
+        username = request.data.get("username")
+        password = request.data.get("password")
+        user = authenticate(username=username, password=password)
+        if user is None:
+            return Response({"detail": "Invalid credentials"}, status=status.HTTP_401_UNAUTHORIZED)
+
+        payload = {
+            "username": user.username,
+            "email": user.email,
+            "iat": datetime.datetime.utcnow(),
+        }
+        token = utils.encode_jwt(payload)
+        return Response({"token": token})

--- a/identity-provider/main/settings.py
+++ b/identity-provider/main/settings.py
@@ -38,6 +38,7 @@ INSTALLED_APPS = [
     "django.contrib.sessions",
     "django.contrib.messages",
     "django.contrib.staticfiles",
+    "rest_framework",
     "identity_app",
 ]
 
@@ -126,3 +127,5 @@ DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 
 # JWT configuration
 JWT_SECRET = os.environ.get("VF_JWT_SECRET", "change-me")
+SSO_COOKIE_DOMAIN = os.environ.get("SSO_COOKIE_DOMAIN", "localhost")
+DEFAULT_REDIRECT_URL = os.environ.get("DEFAULT_REDIRECT_URL", "/")

--- a/identity-provider/main/urls.py
+++ b/identity-provider/main/urls.py
@@ -16,8 +16,9 @@ Including another URLconf
 """
 
 from django.contrib import admin
-from django.urls import path
+from django.urls import path, include
 
 urlpatterns = [
     path("admin/", admin.site.urls),
+    path("", include("identity_app.urls")),
 ]

--- a/inventory-api/inventory/urls.py
+++ b/inventory-api/inventory/urls.py
@@ -1,0 +1,7 @@
+from django.urls import path
+from . import views
+
+urlpatterns = [
+    path('health/', views.health, name='health'),
+    path('private/', views.private, name='private'),
+]

--- a/inventory-api/inventory/views.py
+++ b/inventory-api/inventory/views.py
@@ -1,3 +1,15 @@
-from django.shortcuts import render
+from rest_framework.decorators import api_view, permission_classes
+from rest_framework.permissions import AllowAny, IsAuthenticated
+from rest_framework.response import Response
 
-# Create your views here.
+
+@api_view(["GET"])
+@permission_classes([AllowAny])
+def health(request):
+    return Response({"status": "ok"})
+
+
+@api_view(["GET"])
+@permission_classes([IsAuthenticated])
+def private(request):
+    return Response({"user": request.user.username})

--- a/inventory-api/main/settings.py
+++ b/inventory-api/main/settings.py
@@ -38,6 +38,7 @@ INSTALLED_APPS = [
     "django.contrib.sessions",
     "django.contrib.messages",
     "django.contrib.staticfiles",
+    "rest_framework",
     "inventory",
 ]
 
@@ -126,3 +127,5 @@ DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 
 # JWT configuration
 JWT_SECRET = os.environ.get("VF_JWT_SECRET", "change-me")
+SSO_COOKIE_DOMAIN = os.environ.get("SSO_COOKIE_DOMAIN", "localhost")
+DEFAULT_REDIRECT_URL = os.environ.get("DEFAULT_REDIRECT_URL", "/")

--- a/inventory-api/main/urls.py
+++ b/inventory-api/main/urls.py
@@ -16,8 +16,9 @@ Including another URLconf
 """
 
 from django.contrib import admin
-from django.urls import path
+from django.urls import path, include
 
 urlpatterns = [
     path("admin/", admin.site.urls),
+    path("", include("inventory.urls")),
 ]

--- a/scripts/get_dev_certs.sh
+++ b/scripts/get_dev_certs.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -e
+CERT_DIR="certs"
+DOMAIN="${DEV_DOMAIN:-localhost}"
+mkdir -p "$CERT_DIR"
+openssl req -x509 -newkey rsa:2048 -nodes -keyout "$CERT_DIR/privkey.pem" \
+    -out "$CERT_DIR/fullchain.pem" -days 365 -subj "/CN=$DOMAIN"
+echo "Certificates generated in $CERT_DIR" 

--- a/website/main/settings.py
+++ b/website/main/settings.py
@@ -38,6 +38,7 @@ INSTALLED_APPS = [
     "django.contrib.sessions",
     "django.contrib.messages",
     "django.contrib.staticfiles",
+    "rest_framework",
     "webapp",
 ]
 
@@ -126,3 +127,5 @@ DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 
 # JWT configuration
 JWT_SECRET = os.environ.get("VF_JWT_SECRET", "change-me")
+SSO_COOKIE_DOMAIN = os.environ.get("SSO_COOKIE_DOMAIN", "localhost")
+DEFAULT_REDIRECT_URL = os.environ.get("DEFAULT_REDIRECT_URL", "/")

--- a/website/main/urls.py
+++ b/website/main/urls.py
@@ -16,8 +16,9 @@ Including another URLconf
 """
 
 from django.contrib import admin
-from django.urls import path
+from django.urls import path, include
 
 urlpatterns = [
     path("admin/", admin.site.urls),
+    path("", include("webapp.urls")),
 ]

--- a/website/webapp/templates/webapp/index.html
+++ b/website/webapp/templates/webapp/index.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<html>
+<head><title>Demo Site</title></head>
+<body>
+  <h1>Welcome to the Demo Website</h1>
+</body>
+</html>

--- a/website/webapp/urls.py
+++ b/website/webapp/urls.py
@@ -1,0 +1,6 @@
+from django.urls import path
+from . import views
+
+urlpatterns = [
+    path('', views.home, name='home'),
+]

--- a/website/webapp/views.py
+++ b/website/webapp/views.py
@@ -1,3 +1,6 @@
 from django.shortcuts import render
 
-# Create your views here.
+
+def home(request):
+    """Render the demo home page."""
+    return render(request, "webapp/index.html")


### PR DESCRIPTION
## Summary
- implement demo login/logout and DRF login API
- add DRF health and private endpoints for billing and inventory services
- create demo website page
- add script for generating dev certificates and run via Makefile
- update documentation and changelog

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68496ce5e8608330a3d107f39a92bc95