### PR TITLE
Fix Makefile tabs and document LetsEncrypt

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -9,3 +9,4 @@
 - Replaced self-signed cert generation with Let's Encrypt via Docker Compose.
 - Updated Makefile to run all Django projects with runserver_plus over HTTPS.
 - Documented domain configuration and Cloudflare-based certificate flow.
+- Fixed Makefile tab issues and added `LetsEncrypt.md` documentation.

--- a/LetsEncrypt.md
+++ b/LetsEncrypt.md
@@ -1,0 +1,27 @@
+# Let's Encrypt Certificates
+
+This project uses real HTTPS certificates from Let's Encrypt when running the development servers. Certificates are obtained using Certbot with the Cloudflare DNS challenge.
+
+## Obtaining Certificates
+
+Run the following command once you have the required environment variables set:
+
+```bash
+make dev-cert
+```
+
+This runs `scripts/get_dev_certs.sh`, which in turn executes Certbot in a Docker container defined in `docker-compose.yml`.
+
+### Required Environment Variables
+
+- `CLOUDFLARE_API_TOKEN` – API token with permission to modify DNS records for the development domain.
+- `LETSENCRYPT_EMAIL` – email address used when requesting certificates.
+- `DEV_DOMAIN` – base domain for development (defaults to `vlservices.viloforge.com`).
+
+The generated certificates are stored under `certs/live/<DEV_DOMAIN>/` as `fullchain.pem` and `privkey.pem`.
+
+## Using Certificates
+
+The Makefile passes the certificate and key to each Django project's `runserver_plus` command using the `--cert-file` and `--key-file` options. When running `make up`, each service starts with HTTPS enabled using the files from the `certs` directory.
+
+Ensure the certificates exist before running the servers.

--- a/Makefile
+++ b/Makefile
@@ -7,36 +7,34 @@ KEY_FILE ?= $(CERT_DIR)/privkey.pem
 .PHONY: up dev-cert
 
 up:
-$(MAKE) -j4 run-identity run-website run-billing run-inventory
+	$(MAKE) -j4 run-identity run-website run-billing run-inventory
 
 run-identity:
-VF_JWT_SECRET=$(VF_JWT_SECRET) \
-SSO_COOKIE_DOMAIN=.${DEV_DOMAIN} \
-python identity-provider/manage.py runserver_plus 8001 \
-    --cert-file $(CERT_FILE) --key-file $(KEY_FILE)
+	VF_JWT_SECRET=$(VF_JWT_SECRET) \
+	SSO_COOKIE_DOMAIN=.${DEV_DOMAIN} \
+	python identity-provider/manage.py runserver_plus 8001 \
+	    --cert-file $(CERT_FILE) --key-file $(KEY_FILE)
 
 run-website:
-VF_JWT_SECRET=$(VF_JWT_SECRET) \
-SSO_COOKIE_DOMAIN=.${DEV_DOMAIN} \
-python website/manage.py runserver_plus 8002 \
-    --cert-file $(CERT_FILE) --key-file $(KEY_FILE)
+	VF_JWT_SECRET=$(VF_JWT_SECRET) \
+	SSO_COOKIE_DOMAIN=.${DEV_DOMAIN} \
+	python website/manage.py runserver_plus 8002 \
+	    --cert-file $(CERT_FILE) --key-file $(KEY_FILE)
 
 run-billing:
-VF_JWT_SECRET=$(VF_JWT_SECRET) \
-SSO_COOKIE_DOMAIN=.${DEV_DOMAIN} \
-python billing-api/manage.py runserver_plus 8003 \
-    --cert-file $(CERT_FILE) --key-file $(KEY_FILE)
+	VF_JWT_SECRET=$(VF_JWT_SECRET) \
+	SSO_COOKIE_DOMAIN=.${DEV_DOMAIN} \
+	python billing-api/manage.py runserver_plus 8003 \
+	    --cert-file $(CERT_FILE) --key-file $(KEY_FILE)
 
 run-inventory:
-VF_JWT_SECRET=$(VF_JWT_SECRET) \
-SSO_COOKIE_DOMAIN=.${DEV_DOMAIN} \
-python inventory-api/manage.py runserver_plus 8004 \
-    --cert-file $(CERT_FILE) --key-file $(KEY_FILE)
-
+	VF_JWT_SECRET=$(VF_JWT_SECRET) \
+	SSO_COOKIE_DOMAIN=.${DEV_DOMAIN} \
+	python inventory-api/manage.py runserver_plus 8004 \
+	    --cert-file $(CERT_FILE) --key-file $(KEY_FILE)
 
 device-cert:
-@echo "Deprecated target name: use dev-cert"
-
+	@echo "Deprecated target name: use dev-cert"
 
 dev-cert:
-./scripts/get_dev_certs.sh
+	./scripts/get_dev_certs.sh

--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@ export VF_JWT_SECRET="super-secret-key"
 
 Before running the servers you will need valid HTTPS certificates. These are
 retrieved from Let's Encrypt using a Dockerized Certbot image. Provide your
-Cloudflare API token and email via environment variables and run:
+Cloudflare API token and email via environment variables and run
+`make dev-cert` (see `LetsEncrypt.md` for details):
 
 ```bash
 export CLOUDFLARE_API_TOKEN="<token>"


### PR DESCRIPTION
## Summary
- fix indentation in Makefile targets
- cross-reference new documentation from README
- add LetsEncrypt.md explaining certificate retrieval
- update Changelog

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68497593df248330a7cfc07f8bb8d106