### PR TITLE
Fix runserver_plus setup

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -10,3 +10,5 @@
 - Updated Makefile to run all Django projects with runserver_plus over HTTPS.
 - Documented domain configuration and Cloudflare-based certificate flow.
 - Fixed Makefile tab issues and added `LetsEncrypt.md` documentation.
+- Added `django_extensions` to each project's `INSTALLED_APPS` so
+  `runserver_plus` works correctly during development.

--- a/README.md
+++ b/README.md
@@ -23,6 +23,10 @@ pip install -r requirements.txt
 export VF_JWT_SECRET="super-secret-key"
 ```
 
+The servers run with `runserver_plus` from **django-extensions** to enable
+HTTPS in development. This package is installed from `requirements.txt`, and
+each project includes `django_extensions` in `INSTALLED_APPS`.
+
 Before running the servers you will need valid HTTPS certificates. These are
 retrieved from Let's Encrypt using a Dockerized Certbot image. Provide your
 Cloudflare API token and email via environment variables and run

--- a/billing-api/main/settings.py
+++ b/billing-api/main/settings.py
@@ -39,6 +39,7 @@ INSTALLED_APPS = [
     "django.contrib.messages",
     "django.contrib.staticfiles",
     "rest_framework",
+    "django_extensions",
     "billing",
 ]
 

--- a/identity-provider/main/settings.py
+++ b/identity-provider/main/settings.py
@@ -39,6 +39,7 @@ INSTALLED_APPS = [
     "django.contrib.messages",
     "django.contrib.staticfiles",
     "rest_framework",
+    "django_extensions",
     "identity_app",
 ]
 

--- a/inventory-api/main/settings.py
+++ b/inventory-api/main/settings.py
@@ -39,6 +39,7 @@ INSTALLED_APPS = [
     "django.contrib.messages",
     "django.contrib.staticfiles",
     "rest_framework",
+    "django_extensions",
     "inventory",
 ]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-django-extensions
 djangorestframework
 django
 pytest

--- a/website/main/settings.py
+++ b/website/main/settings.py
@@ -39,6 +39,7 @@ INSTALLED_APPS = [
     "django.contrib.messages",
     "django.contrib.staticfiles",
     "rest_framework",
+    "django_extensions",
     "webapp",
 ]
 


### PR DESCRIPTION
## Summary
- allow runserver_plus by adding django_extensions to each settings file
- dedupe requirements
- document runserver_plus usage
- update changelog

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a9ad9ebbc83308ae39b4c423cb572