### PR TITLE
Automate DB setup on startup

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -12,3 +12,5 @@
 - Fixed Makefile tab issues and added `LetsEncrypt.md` documentation.
 - Added `django_extensions` to each project's `INSTALLED_APPS` so
   `runserver_plus` works correctly during development.
+- Makefile now initializes SQLite databases automatically if they do not exist
+  and sets `PYTHONPATH` so shared `common` modules import correctly.

--- a/Makefile
+++ b/Makefile
@@ -10,28 +10,40 @@ up:
 	$(MAKE) -j4 run-identity run-website run-billing run-inventory
 
 run-identity:
+	if [ ! -f identity-provider/db.sqlite3 ]; then \
+	       PYTHONPATH=$(PWD) python identity-provider/manage.py migrate --noinput; \
+	fi; \
 	VF_JWT_SECRET=$(VF_JWT_SECRET) \
 	SSO_COOKIE_DOMAIN=.${DEV_DOMAIN} \
-	python identity-provider/manage.py runserver_plus 8001 \
-	    --cert-file $(CERT_FILE) --key-file $(KEY_FILE)
+	PYTHONPATH=$(PWD) python identity-provider/manage.py runserver_plus 8001 \
+	   --cert-file $(CERT_FILE) --key-file $(KEY_FILE)
 
 run-website:
+	if [ ! -f website/db.sqlite3 ]; then \
+	       PYTHONPATH=$(PWD) python website/manage.py migrate --noinput; \
+	fi; \
 	VF_JWT_SECRET=$(VF_JWT_SECRET) \
 	SSO_COOKIE_DOMAIN=.${DEV_DOMAIN} \
-	python website/manage.py runserver_plus 8002 \
-	    --cert-file $(CERT_FILE) --key-file $(KEY_FILE)
+	PYTHONPATH=$(PWD) python website/manage.py runserver_plus 8002 \
+	   --cert-file $(CERT_FILE) --key-file $(KEY_FILE)
 
 run-billing:
+	if [ ! -f billing-api/db.sqlite3 ]; then \
+	       PYTHONPATH=$(PWD) python billing-api/manage.py migrate --noinput; \
+	fi; \
 	VF_JWT_SECRET=$(VF_JWT_SECRET) \
 	SSO_COOKIE_DOMAIN=.${DEV_DOMAIN} \
-	python billing-api/manage.py runserver_plus 8003 \
-	    --cert-file $(CERT_FILE) --key-file $(KEY_FILE)
+	PYTHONPATH=$(PWD) python billing-api/manage.py runserver_plus 8003 \
+	   --cert-file $(CERT_FILE) --key-file $(KEY_FILE)
 
 run-inventory:
+	if [ ! -f inventory-api/db.sqlite3 ]; then \
+	       PYTHONPATH=$(PWD) python inventory-api/manage.py migrate --noinput; \
+	fi; \
 	VF_JWT_SECRET=$(VF_JWT_SECRET) \
 	SSO_COOKIE_DOMAIN=.${DEV_DOMAIN} \
-	python inventory-api/manage.py runserver_plus 8004 \
-	    --cert-file $(CERT_FILE) --key-file $(KEY_FILE)
+	PYTHONPATH=$(PWD) python inventory-api/manage.py runserver_plus 8004 \
+	   --cert-file $(CERT_FILE) --key-file $(KEY_FILE)
 
 device-cert:
 	@echo "Deprecated target name: use dev-cert"

--- a/README.md
+++ b/README.md
@@ -45,6 +45,10 @@ Once certificates exist you can start all services at once:
 make up
 ```
 
+The Makefile will automatically create the local SQLite databases for each
+project on first run by executing `python manage.py migrate` when the database
+file is missing. Subsequent runs will skip this step.
+
 Ensure your hosts file resolves the development subdomains to localhost:
 
 ```


### PR DESCRIPTION
## Summary
- initialize SQLite DBs automatically in `make up`
- document auto-migration behavior in README
- note automatic DB initialization in the changelog

## Testing
- `pytest -q`
- `make up` *(fails: FileNotFoundError for missing SSL certificates)*

------
https://chatgpt.com/codex/tasks/task_e_684a9db65b54833086eb0cd4e58f7bc3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The development setup now automatically initializes local SQLite databases if they are missing when starting services.
- **Documentation**
  - Updated documentation and changelog to explain the new automatic database creation and environment configuration behavior in the Makefile.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->