### PR TITLE
Add services to docker-compose

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -15,3 +15,5 @@
 - Makefile now initializes SQLite databases automatically if they do not exist
   and sets `PYTHONPATH` so shared `common` modules import correctly.
 - Added Dockerfiles for each project and docker-compose.dev.yml using Traefik for development.
+- docker-compose.yml now starts all Django projects with Traefik and mounts the source
+  directories so code changes reload immediately.

--- a/README.md
+++ b/README.md
@@ -60,12 +60,12 @@ Ensure your hosts file resolves the development subdomains to localhost:
 
 ## Docker-based Development
 
-You can also run the projects using Docker. Each project includes a `Dockerfile` and a common compose file `docker-compose.dev.yml` starts them together with [Traefik](https://traefik.io) for routing. Services run on plain HTTP and are reloaded whenever code changes because the project directories are mounted as bind volumes.
+You can also run the projects using Docker. Each project includes a `Dockerfile` and the main compose file `docker-compose.yml` starts them together with [Traefik](https://traefik.io) for routing. Services run on plain HTTP and are reloaded whenever code changes because the project directories are mounted as bind volumes.
 
 Start the stack with:
 
 ```bash
-docker compose -f docker-compose.dev.yml up --build
+docker compose up --build
 ```
 
 Traefik listens on port 80 and routes based on subdomain. Ensure your hosts file maps the development domain to `localhost`, for example:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,84 @@
 version: '3.8'
 services:
+  traefik:
+    image: traefik:v2.11
+    command:
+      - --providers.docker=true
+      - --providers.docker.exposedbydefault=false
+      - --entrypoints.web.address=:80
+    ports:
+      - "80:80"
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+
+  identity-provider:
+    build:
+      context: .
+      dockerfile: identity-provider/Dockerfile
+    working_dir: /code/identity-provider
+    volumes:
+      - ./identity-provider:/code/identity-provider
+      - ./common:/code/common
+    environment:
+      - PYTHONPATH=/code
+      - VF_JWT_SECRET=${VF_JWT_SECRET:-change-me}
+      - SSO_COOKIE_DOMAIN=.${DEV_DOMAIN:-vfservices.viloforge.com}
+    labels:
+      - traefik.enable=true
+      - traefik.http.routers.identity.rule=Host(`login.${DEV_DOMAIN:-vfservices.viloforge.com}`)
+      - traefik.http.services.identity.loadbalancer.server.port=8000
+
+  website:
+    build:
+      context: .
+      dockerfile: website/Dockerfile
+    working_dir: /code/website
+    volumes:
+      - ./website:/code/website
+      - ./common:/code/common
+    environment:
+      - PYTHONPATH=/code
+      - VF_JWT_SECRET=${VF_JWT_SECRET:-change-me}
+      - SSO_COOKIE_DOMAIN=.${DEV_DOMAIN:-vfservices.viloforge.com}
+    labels:
+      - traefik.enable=true
+      - traefik.http.routers.website.rule=Host(`website.${DEV_DOMAIN:-vfservices.viloforge.com}`)
+      - traefik.http.services.website.loadbalancer.server.port=8000
+
+  billing-api:
+    build:
+      context: .
+      dockerfile: billing-api/Dockerfile
+    working_dir: /code/billing-api
+    volumes:
+      - ./billing-api:/code/billing-api
+      - ./common:/code/common
+    environment:
+      - PYTHONPATH=/code
+      - VF_JWT_SECRET=${VF_JWT_SECRET:-change-me}
+      - SSO_COOKIE_DOMAIN=.${DEV_DOMAIN:-vfservices.viloforge.com}
+    labels:
+      - traefik.enable=true
+      - traefik.http.routers.billing.rule=Host(`billing-api.${DEV_DOMAIN:-vfservices.viloforge.com}`)
+      - traefik.http.services.billing.loadbalancer.server.port=8000
+
+  inventory-api:
+    build:
+      context: .
+      dockerfile: inventory-api/Dockerfile
+    working_dir: /code/inventory-api
+    volumes:
+      - ./inventory-api:/code/inventory-api
+      - ./common:/code/common
+    environment:
+      - PYTHONPATH=/code
+      - VF_JWT_SECRET=${VF_JWT_SECRET:-change-me}
+      - SSO_COOKIE_DOMAIN=.${DEV_DOMAIN:-vfservices.viloforge.com}
+    labels:
+      - traefik.enable=true
+      - traefik.http.routers.inventory.rule=Host(`inventory-api.${DEV_DOMAIN:-vfservices.viloforge.com}`)
+      - traefik.http.services.inventory.loadbalancer.server.port=8000
+
   certbot:
     image: certbot/dns-cloudflare
     volumes:
@@ -10,3 +89,7 @@ services:
       - LETSENCRYPT_EMAIL=${LETSENCRYPT_EMAIL}
       - DEV_DOMAIN=${DEV_DOMAIN:-vfservices.viloforge.com}
     entrypoint: ["sh", "/run_certbot.sh"]
+
+networks:
+  default:
+    name: vfnet


### PR DESCRIPTION
## Summary
- include Django services and Traefik in docker-compose.yml
- update README for new compose usage
- document compose change in Changelog

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b0a1773d883308032d60307b435a5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Traefik as a reverse proxy for all services, enabling routing based on hostnames.
  - Introduced new services: identity provider, website, billing API, and inventory API, each with live code reload support.
- **Documentation**
  - Updated README and changelog to reflect changes in Docker Compose usage and service orchestration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->