### PR TITLE
Ensure identity-provider creates default admin user

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -17,3 +17,4 @@
 - Added Dockerfiles for each project and docker-compose.dev.yml using Traefik for development.
 - docker-compose.yml now starts all Django projects with Traefik and mounts the source
   directories so code changes reload immediately.
+- Identity provider now ensures a default `admin` user exists with password `admin` when started via Docker.

--- a/README.md
+++ b/README.md
@@ -79,3 +79,8 @@ Traefik listens on port 80 and routes based on subdomain. Ensure your hosts file
 
 Then open `http://website.vfservices.viloforge.com` in your browser.
 
+The identity provider automatically creates a default administrative user named
+`admin` with password `admin` the first time it starts if the user does not
+already exist. Use these credentials to sign into the Django admin or login
+page during development.
+

--- a/identity-provider/identity_app/apps.py
+++ b/identity-provider/identity_app/apps.py
@@ -1,6 +1,39 @@
+import logging
+import os
+
 from django.apps import AppConfig
 
 
 class IdentityAppConfig(AppConfig):
     default_auto_field = "django.db.models.BigAutoField"
     name = "identity_app"
+
+    def ready(self) -> None:
+        """Ensure a default admin user exists when the app starts."""
+        if os.environ.get("RUN_MAIN") != "true":
+            # Avoid running twice when the autoreloader spawns a child process.
+            return
+        self._ensure_default_admin()
+
+    def _ensure_default_admin(self) -> None:
+        """Create a default admin user if none exists."""
+        from django.contrib.auth import get_user_model
+        from django.db.utils import OperationalError, ProgrammingError
+
+        logger = logging.getLogger(__name__)
+        User = get_user_model()
+
+        try:
+            User.objects.get(username="admin")
+        except User.DoesNotExist:
+            try:
+                User.objects.create_superuser(
+                    "admin",
+                    "admin@example.com",
+                    "admin",
+                )
+                logger.info("Created default admin user")
+            except (OperationalError, ProgrammingError) as exc:
+                logger.warning("Could not create admin user: %s", exc)
+        except (OperationalError, ProgrammingError) as exc:
+            logger.warning("Admin user check failed: %s", exc)


### PR DESCRIPTION
## Summary
- auto-create default admin user when identity provider starts
- document the default admin credentials
- note the behaviour in the changelog

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684bd824636483309ab10a6f512cf7a8