### PR TITLE
Add PostgreSQL support and migration entrypoints

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -18,3 +18,5 @@
 - docker-compose.yml now starts all Django projects with Traefik and mounts the source
   directories so code changes reload immediately.
 - Identity provider now ensures a default `admin` user exists with password `admin` when started via Docker.
+- Switched all services to PostgreSQL via a new container.
+- Added entrypoint scripts that run migrations on startup for each Django project.

--- a/README.md
+++ b/README.md
@@ -45,9 +45,10 @@ Once certificates exist you can start all services at once:
 make up
 ```
 
-The Makefile will automatically create the local SQLite databases for each
-project on first run by executing `python manage.py migrate` when the database
-file is missing. Subsequent runs will skip this step.
+Prior versions of the repository used SQLite databases that the Makefile
+initialised automatically. The stack now relies on a shared PostgreSQL
+container so no local database files are created. Migrations are applied
+automatically at container start up by each project's `entrypoint.sh`.
 
 Ensure your hosts file resolves the development subdomains to localhost:
 
@@ -60,7 +61,7 @@ Ensure your hosts file resolves the development subdomains to localhost:
 
 ## Docker-based Development
 
-You can also run the projects using Docker. Each project includes a `Dockerfile` and the main compose file `docker-compose.yml` starts them together with [Traefik](https://traefik.io) for routing. Services run on plain HTTP and are reloaded whenever code changes because the project directories are mounted as bind volumes.
+You can also run the projects using Docker. Each project includes a `Dockerfile` and the main compose file `docker-compose.yml` starts them together with [Traefik](https://traefik.io) for routing **and a PostgreSQL container**. Services run on plain HTTP and are reloaded whenever code changes because the project directories are mounted as bind volumes.
 
 Start the stack with:
 
@@ -76,6 +77,11 @@ Traefik listens on port 80 and routes based on subdomain. Ensure your hosts file
 127.0.0.1 billing-api.vfservices.viloforge.com
 127.0.0.1 inventory-api.vfservices.viloforge.com
 ```
+
+The compose file also starts a `postgres` container. Each Django service is
+configured via environment variables (`POSTGRES_HOST`, `POSTGRES_DB`,
+`POSTGRES_USER`, and `POSTGRES_PASSWORD`) to connect to this database and runs
+migrations on start up.
 
 Then open `http://website.vfservices.viloforge.com` in your browser.
 

--- a/billing-api/Dockerfile
+++ b/billing-api/Dockerfile
@@ -4,4 +4,7 @@ COPY requirements.txt /tmp/requirements.txt
 RUN pip install --no-cache-dir -r /tmp/requirements.txt
 COPY . /code/billing-api
 ENV PYTHONPATH=/code
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]
 CMD ["python", "manage.py", "runserver", "0.0.0.0:8000"]

--- a/billing-api/entrypoint.sh
+++ b/billing-api/entrypoint.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+set -e
+python manage.py migrate --noinput
+exec "$@"

--- a/billing-api/main/settings.py
+++ b/billing-api/main/settings.py
@@ -79,8 +79,12 @@ WSGI_APPLICATION = "main.wsgi.application"
 
 DATABASES = {
     "default": {
-        "ENGINE": "django.db.backends.sqlite3",
-        "NAME": BASE_DIR / "db.sqlite3",
+        "ENGINE": "django.db.backends.postgresql",
+        "NAME": os.environ.get("POSTGRES_DB", "vfdb"),
+        "USER": os.environ.get("POSTGRES_USER", "vfuser"),
+        "PASSWORD": os.environ.get("POSTGRES_PASSWORD", "vfpass"),
+        "HOST": os.environ.get("POSTGRES_HOST", "localhost"),
+        "PORT": os.environ.get("POSTGRES_PORT", "5432"),
     }
 }
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,6 +29,15 @@ services:
       - CLOUDFLARE_TOKEN=${CLOUDFLARE_API_TOKEN}
     entrypoint: /bin/sh
 
+  postgres:
+    image: postgres:16-alpine
+    environment:
+      - POSTGRES_USER=${POSTGRES_USER:-vfuser}
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-vfpass}
+      - POSTGRES_DB=${POSTGRES_DB:-vfdb}
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+
   identity-provider:
     build:
       context: .
@@ -41,6 +50,10 @@ services:
       - PYTHONPATH=/code
       - VF_JWT_SECRET=${VF_JWT_SECRET:-change-me}
       - SSO_COOKIE_DOMAIN=.${DEV_DOMAIN:-vfservices.viloforge.com}
+      - POSTGRES_HOST=postgres
+      - POSTGRES_DB=${POSTGRES_DB:-vfdb}
+      - POSTGRES_USER=${POSTGRES_USER:-vfuser}
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-vfpass}
     labels:
       - "traefik.enable=true"
       - "traefik.http.routers.identity.rule=Host(`identity.${DEV_DOMAIN:-vfservices.viloforge.com}`)"
@@ -61,6 +74,10 @@ services:
       - PYTHONPATH=/code
       - VF_JWT_SECRET=${VF_JWT_SECRET:-change-me}
       - SSO_COOKIE_DOMAIN=.${DEV_DOMAIN:-vfservices.viloforge.com}
+      - POSTGRES_HOST=postgres
+      - POSTGRES_DB=${POSTGRES_DB:-vfdb}
+      - POSTGRES_USER=${POSTGRES_USER:-vfuser}
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-vfpass}
     labels:
       - "traefik.enable=true"
       - "traefik.http.routers.website.rule=Host(`website.${DEV_DOMAIN:-vfservices.viloforge.com}`)"
@@ -81,6 +98,10 @@ services:
       - PYTHONPATH=/code
       - VF_JWT_SECRET=${VF_JWT_SECRET:-change-me}
       - SSO_COOKIE_DOMAIN=.${DEV_DOMAIN:-vfservices.viloforge.com}
+      - POSTGRES_HOST=postgres
+      - POSTGRES_DB=${POSTGRES_DB:-vfdb}
+      - POSTGRES_USER=${POSTGRES_USER:-vfuser}
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-vfpass}
     labels:
       - "traefik.enable=true"
       - "traefik.http.routers.billing.rule=Host(`billing.${DEV_DOMAIN:-vfservices.viloforge.com}`)"
@@ -101,6 +122,10 @@ services:
       - PYTHONPATH=/code
       - VF_JWT_SECRET=${VF_JWT_SECRET:-change-me}
       - SSO_COOKIE_DOMAIN=.${DEV_DOMAIN:-vfservices.viloforge.com}
+      - POSTGRES_HOST=postgres
+      - POSTGRES_DB=${POSTGRES_DB:-vfdb}
+      - POSTGRES_USER=${POSTGRES_USER:-vfuser}
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-vfpass}
     labels:
       - "traefik.enable=true"
       - "traefik.http.routers.inventory.rule=Host(`inventory.${DEV_DOMAIN:-vfservices.viloforge.com}`)"
@@ -112,3 +137,6 @@ services:
 networks:
   default:
     name: vfnet
+
+volumes:
+  pgdata:

--- a/identity-provider/Dockerfile
+++ b/identity-provider/Dockerfile
@@ -4,4 +4,7 @@ COPY requirements.txt /tmp/requirements.txt
 RUN pip install --no-cache-dir -r /tmp/requirements.txt
 COPY . /code/identity-provider
 ENV PYTHONPATH=/code
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]
 CMD ["python", "manage.py", "runserver", "0.0.0.0:8000"]

--- a/identity-provider/entrypoint.sh
+++ b/identity-provider/entrypoint.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+set -e
+python manage.py migrate --noinput
+exec "$@"

--- a/identity-provider/main/settings.py
+++ b/identity-provider/main/settings.py
@@ -82,8 +82,12 @@ WSGI_APPLICATION = "main.wsgi.application"
 
 DATABASES = {
     "default": {
-        "ENGINE": "django.db.backends.sqlite3",
-        "NAME": BASE_DIR / "db.sqlite3",
+        "ENGINE": "django.db.backends.postgresql",
+        "NAME": os.environ.get("POSTGRES_DB", "vfdb"),
+        "USER": os.environ.get("POSTGRES_USER", "vfuser"),
+        "PASSWORD": os.environ.get("POSTGRES_PASSWORD", "vfpass"),
+        "HOST": os.environ.get("POSTGRES_HOST", "localhost"),
+        "PORT": os.environ.get("POSTGRES_PORT", "5432"),
     }
 }
 

--- a/inventory-api/Dockerfile
+++ b/inventory-api/Dockerfile
@@ -4,4 +4,7 @@ COPY requirements.txt /tmp/requirements.txt
 RUN pip install --no-cache-dir -r /tmp/requirements.txt
 COPY . /code/inventory-api
 ENV PYTHONPATH=/code
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]
 CMD ["python", "manage.py", "runserver", "0.0.0.0:8000"]

--- a/inventory-api/entrypoint.sh
+++ b/inventory-api/entrypoint.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+set -e
+python manage.py migrate --noinput
+exec "$@"

--- a/inventory-api/main/settings.py
+++ b/inventory-api/main/settings.py
@@ -79,8 +79,12 @@ WSGI_APPLICATION = "main.wsgi.application"
 
 DATABASES = {
     "default": {
-        "ENGINE": "django.db.backends.sqlite3",
-        "NAME": BASE_DIR / "db.sqlite3",
+        "ENGINE": "django.db.backends.postgresql",
+        "NAME": os.environ.get("POSTGRES_DB", "vfdb"),
+        "USER": os.environ.get("POSTGRES_USER", "vfuser"),
+        "PASSWORD": os.environ.get("POSTGRES_PASSWORD", "vfpass"),
+        "HOST": os.environ.get("POSTGRES_HOST", "localhost"),
+        "PORT": os.environ.get("POSTGRES_PORT", "5432"),
     }
 }
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ pytest
 pydantic2
 PyJWT
 django-extensions
+psycopg2-binary

--- a/website/Dockerfile
+++ b/website/Dockerfile
@@ -4,4 +4,7 @@ COPY requirements.txt /tmp/requirements.txt
 RUN pip install --no-cache-dir -r /tmp/requirements.txt
 COPY . /code/website
 ENV PYTHONPATH=/code
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]
 CMD ["python", "manage.py", "runserver", "0.0.0.0:8000"]

--- a/website/entrypoint.sh
+++ b/website/entrypoint.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+set -e
+python manage.py migrate --noinput
+exec "$@"

--- a/website/main/settings.py
+++ b/website/main/settings.py
@@ -79,8 +79,12 @@ WSGI_APPLICATION = "main.wsgi.application"
 
 DATABASES = {
     "default": {
-        "ENGINE": "django.db.backends.sqlite3",
-        "NAME": BASE_DIR / "db.sqlite3",
+        "ENGINE": "django.db.backends.postgresql",
+        "NAME": os.environ.get("POSTGRES_DB", "vfdb"),
+        "USER": os.environ.get("POSTGRES_USER", "vfuser"),
+        "PASSWORD": os.environ.get("POSTGRES_PASSWORD", "vfpass"),
+        "HOST": os.environ.get("POSTGRES_HOST", "localhost"),
+        "PORT": os.environ.get("POSTGRES_PORT", "5432"),
     }
 }
 


### PR DESCRIPTION
## Summary
- add psycopg2-binary dependency
- introduce a postgres service in docker compose
- configure Django projects to read DB settings from environment
- add entrypoint scripts that run migrations before startup
- update Dockerfiles to use entrypoints
- document postgres usage in README and update changelog

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684bdbdde7f4833090fc3ad2375afc00